### PR TITLE
Relaxing the config schema for backwards compatibility & bug fix

### DIFF
--- a/src/documenters/MarkdownDocumenter.ts
+++ b/src/documenters/MarkdownDocumenter.ts
@@ -1145,7 +1145,7 @@ export class MarkdownDocumenter {
         let apiMembers: ReadonlyArray<ApiItem> = item.members;
         const mdEmitter = this._markdownEmitter;
 
-        var extractSummary = function (docComment: DocComment): string {
+        var extractSummary = (docComment: DocComment): string => {
             const tmpStrBuilder: StringBuilder = new StringBuilder();
             const summary: DocSection = docComment!.summarySection;
             mdEmitter.emit(tmpStrBuilder, summary, {

--- a/src/schemas/api-documenter.schema.json
+++ b/src/schemas/api-documenter.schema.json
@@ -32,7 +32,7 @@
     },
     "onlyPackagesStartingWith": {
       "description": "Specifies how packages must start to be included, so non matching package names are excluded.",
-      "type": "array",
+      "type": ["string", "array"],
       "default": ""
     },
     "newDocfxNamespaces": {


### PR DESCRIPTION
This PR relaxes the config schema as it can support both the usage of a single string and array of strings, this makes the change in the config backwards compatible.

Additionally there is a minor bugfix that was caused because `this` was not captured in a function